### PR TITLE
Add HERON_CONTROL_EXTRAS envar, same as Husky

### DIFF
--- a/heron_control/config/empty.yaml
+++ b/heron_control/config/empty.yaml
@@ -1,0 +1,8 @@
+# The empty Heron extras configuration has nothing in it and should not.
+# It is meant to override the default to add custom control parameters
+# file in your own Heron customization package and setting HERON_CONFIG_EXTRAS
+# to your customization file in the launch file control.launch.
+# Each parameter will need to be loaded in the correct namespace to
+# be used. For example, for a Heron with a modified EKF configuration
+# This can be used to change ekf_localization_node/odom0 and odom0_config
+# parameters to use a different IMU

--- a/heron_control/launch/control.launch
+++ b/heron_control/launch/control.launch
@@ -1,4 +1,7 @@
 <launch>
+  <arg name="config_extras"
+       default="$(eval optenv('HERON_CONFIG_EXTRAS', find('heron_control') + '/config/empty.yaml'))"/>
+
    <node pkg="robot_localization" type="ekf_localization_node" name="ekf_localization_node">
     <rosparam command="load" file="$(find heron_control)/config/robot_localization.yaml" />
   </node>
@@ -11,5 +14,8 @@
   </node>
 
   <node pkg="heron_control" type="vel_cov" name="navsat_vel_cov" />
+
+  <!-- Override the default control parameters, see config/empty.yaml for default. -->
+  <rosparam command="load" file="$(arg config_extras)" />
 
 </launch>


### PR DESCRIPTION
Add the necessary empty config file as the default + support for overriding e.g. EKF settings or velocity limits through an envar pointing to a yaml file.