### PR TITLE
Apply the modified EKF configuration to fix the odom frame drifting

### DIFF
--- a/heron_control/config/robot_localization.yaml
+++ b/heron_control/config/robot_localization.yaml
@@ -16,7 +16,7 @@ use_control: false
 imu0: imu/data
 imu0_config: [false, false, false,
               false, false, false,
-              false, false, true,
+              false, false, false,
               true, true, true,
               false, false, false]
 imu0_nodelay: true

--- a/heron_control/config/robot_localization.yaml
+++ b/heron_control/config/robot_localization.yaml
@@ -15,10 +15,10 @@ use_control: false
 # -------------------------------------
 imu0: imu/data
 imu0_config: [false, false, false,
-              false, false, true,
               false, false, false,
               false, false, true,
-              true, true, false]
+              true, true, true,
+              false, false, false]
 imu0_nodelay: true
 imu0_differential: false
 imu0_relative: false


### PR DESCRIPTION
This should have been done in sept 2020, but it got lost in the shuffle.  Stephen brought it up again in RPPROD-217 and re-applied this fix. Confirmed that it worked correctly to fix the same issue.