### PR TITLE
Add additional teleop dependencies

### DIFF
--- a/heron_control/package.xml
+++ b/heron_control/package.xml
@@ -10,10 +10,14 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>interactive_marker_twist_server</exec_depend>
+  <exec_depend>joy</exec_depend>
+  <exec_depend>python-numpy</exec_depend>
   <exec_depend>robot_localization</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>python-numpy</exec_depend>
+  <exec_depend>teleop_twist_joy</exec_depend>
 
   <test_depend>roslaunch</test_depend>
 


### PR DESCRIPTION
heron_control/teleop.launch uses the interactive twist server, joy, and teleop_twist_joy packages, but these weren't marked as explicit dependencies and could be skipped when building from source.
Alphabetize the exec_depends