### PR TITLE
Compatibility change to sensors.xacro for noetic(python3).

### DIFF
--- a/heron_description/urdf/sensors.xacro
+++ b/heron_description/urdf/sensors.xacro
@@ -4,7 +4,7 @@
   <!-- GPS -->
   <gazebo>
     <xacro:property name="datum_env" value="$(optenv GPS_DATUM '49.9, 8.9')"/>
-    <xacro:property name="datum" value="${map(float, datum_env.split(','))}" />
+    <xacro:property name="datum" value="${list(map(float, datum_env.split(',')))}" />
     <xacro:property name="datum_lat" value="${datum[0]}" />
     <xacro:property name="datum_lon" value="${datum[1]}" />
     <plugin name="gps_controller" filename="libhector_gazebo_ros_gps.so">


### PR DESCRIPTION
In python 3, map objects are not subscriptable. This is a fix to sensors.xacro that allows heron_description to be used with noetic also.